### PR TITLE
downgrade noise to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "wait-on": "^6.0.1"
   },
   "dependencies": {
-    "@chainsafe/libp2p-noise": "^9.0.0",
+    "@chainsafe/libp2p-noise": "^8.0.0",
     "@libp2p/components": "^3.1.1",
     "@libp2p/interface-connection": "^3.0.2",
     "@libp2p/interface-registrar": "^2.0.3",


### PR DESCRIPTION
Downgrade the noise dependency to 8.0.0 until libp2p makes a new release.