### PR TITLE
Build dist when installing from gh repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lint:fix": "aegir lint --fix",
     "clean": "aegir clean",
     "dep-check": "aegir dep-check",
+    "prepare": "npm run build",
     "release": "aegir release"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "*",
         "dist/*",
         "dist/src/*",
+        "dist/proto_ts/*",
         "dist/src/*/index"
       ],
       "src/*": [
@@ -40,7 +41,9 @@
   },
   "files": [
     "src",
+    "proto_ts",
     "dist/src",
+    "dist/proto_ts",
     "!dist/test",
     "!**/*.tsbuildinfo"
   ],


### PR DESCRIPTION
With reference to #58 , the repository does not get built when running `npm install little-bear-labs/js-libp2p-webrtc`. A prepare script has been added to ensure that the dist folder is built. This is temporary and will be removed before moving this to libp2p.